### PR TITLE
[Ursa Log Analyzer] Support proto or go struct object to parquet file

### DIFF
--- a/example/proto_write.go
+++ b/example/proto_write.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"log"
+
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/writer"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type JobStatus int32
+
+const (
+	JobStatus_JobStatus_UNSPECIFIED  JobStatus = 0
+	JobStatus_BLOCKED                JobStatus = 1
+	JobStatus_ENQUEUED               JobStatus = 2
+	JobStatus_RUNNING                JobStatus = 3
+	JobStatus_COMPLETED              JobStatus = 4
+	JobStatus_ERRORED                JobStatus = 5
+	JobStatus_CANCELLED              JobStatus = 6
+	JobStatus_UPSTREAM_NOT_PROCESSED JobStatus = 7
+)
+
+func (x JobStatus) Enum() *JobStatus {
+	p := new(JobStatus)
+	*p = x
+	return p
+}
+
+func (x JobStatus) String() string {
+	statusToName := map[int32]string{
+		0: "ASYNCJOBSTATUS_UNSPECIFIED",
+		1: "BLOCKED",
+		2: "ENQUEUED",
+		3: "RUNNING",
+		4: "COMPLETED",
+		5: "ERRORED",
+		6: "CANCELLED",
+		7: "UPSTREAM_NOT_PROCESSED",
+	}
+	return statusToName[int32(x)]
+}
+
+type ProtoMessage struct {
+	Timestamp timestamppb.Timestamp
+	Status    JobStatus
+	IntVal    int32
+}
+
+func main() {
+	protoMessages := []interface{}{
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: 1000000}, Status: JobStatus_RUNNING, IntVal: 1},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: 1000000}, Status: JobStatus_ENQUEUED, IntVal: 2},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: 1000000}, Status: JobStatus_COMPLETED, IntVal: 3},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: 1000000}, Status: JobStatus_ERRORED, IntVal: 4},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: 1000000}, Status: JobStatus_CANCELLED, IntVal: 5},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: 1000000}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6},
+	}
+
+	fw, err := local.NewLocalFileWriter("output/proto_message.parquet")
+	if err != nil {
+		log.Println("Can't create file", err)
+		return
+	}
+	pw, err := writer.NewParquetWriterFromProto(fw, new(ProtoMessage), 1)
+	if err != nil {
+		log.Println("Can't create parquet writer", err)
+		return
+	}
+	for _, message := range protoMessages {
+		if err = pw.Write(message); err != nil {
+			log.Println("Write error", err)
+			return
+		}
+	}
+	if err = pw.WriteStop(); err != nil {
+		log.Println("WriteStop error", err)
+	}
+	fw.Close()
+	log.Println("Write Finished")
+
+}

--- a/example/testelement_write.go
+++ b/example/testelement_write.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/writer"
+)
+
+type subElem struct {
+	Val string
+}
+
+type testNestedElem struct {
+	SubElem     subElem
+	SubPtr      *subElem
+	SubList     []subElem
+	SubRepeated []*subElem
+}
+
+func main() {
+	testNestedElems := []interface{}{
+		testNestedElem{},
+		testNestedElem{SubElem: subElem{Val: "hi"}},
+		testNestedElem{SubPtr: &subElem{Val: "hi"}},
+		testNestedElem{SubList: []subElem{}},
+		testNestedElem{SubList: []subElem{{Val: "hi"}}},
+		testNestedElem{SubList: []subElem{{Val: "hi"}, {}, {Val: "there"}}},
+		testNestedElem{SubRepeated: []*subElem{}},
+		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}}},
+		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}, nil, {Val: "there"}}},
+	}
+	fw, err := local.NewLocalFileWriter("output/testelement.parquet")
+	if err != nil {
+		log.Println("Can't create file", err)
+		return
+	}
+	schemaHandler, err := schema.NewSchemaHandlerFromProtoStruct(new(testNestedElem))
+	if err != nil {
+		log.Println("failed to create the schema handler: %v", err)
+	}
+	pw, err := writer.NewParquetWriter(fw, schemaHandler, 1)
+	if err != nil {
+		log.Println("Can't create parquet writer", err)
+		return
+	}
+	for _, stu := range testNestedElems {
+		if err = pw.Write(stu); err != nil {
+			log.Println("Write error", err)
+			return
+		}
+	}
+	if err = pw.WriteStop(); err != nil {
+		log.Println("WriteStop error", err)
+	}
+	fw.Close()
+	log.Println("Write Finished")
+}

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -18,8 +18,8 @@ type Node struct {
 	DL      int32
 }
 
-//Improve Performance///////////////////////////
-//NodeBuf
+// Improve Performance///////////////////////////
+// NodeBuf
 type NodeBufType struct {
 	Index int
 	Buf   []*Node
@@ -47,7 +47,7 @@ func (nbt *NodeBufType) Reset() {
 	nbt.Index = 0
 }
 
-////////for improve performance///////////////////////////////////
+// //////for improve performance///////////////////////////////////
 type Marshaler interface {
 	Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) (newStack []*Node)
 }
@@ -223,24 +223,9 @@ func (p *ParquetMap) Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) []
 	return stack
 }
 
-//Convert the objects to table map. srcInterface is a slice of objects
-func Marshal(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New("unkown error")
-			}
-		}
-	}()
-
+func InitMarshal(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (*reflect.Value, *NodeBufType, map[string]*layout.Table) {
 	src := reflect.ValueOf(srcInterface)
 	res := setupTableMap(schemaHandler, len(srcInterface))
-	pathMap := schemaHandler.PathMap
 	nodeBuf := NewNodeBuf(1)
 
 	for i := 0; i < len(schemaHandler.SchemaElements); i++ {
@@ -262,7 +247,29 @@ func Marshal(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (t
 			res[pathStr] = table
 		}
 	}
+	return &src, nodeBuf, res
+}
 
+func Marshal(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
+	return MarshalStruct(srcInterface, schemaHandler, false)
+}
+
+// Convert the objects to table map. srcInterface is a slice of objects
+func MarshalStruct(srcInterface []interface{}, schemaHandler *schema.SchemaHandler, isProto bool) (tb *map[string]*layout.Table, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("unkown error")
+			}
+		}
+	}()
+	src, nodeBuf, res := InitMarshal(srcInterface, schemaHandler)
+	pathMap := schemaHandler.PathMap
 	stack := make([]*Node, 0, 100)
 	for i := 0; i < len(srcInterface); i++ {
 		stack = stack[:0]
@@ -277,63 +284,84 @@ func Marshal(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (t
 		stack = append(stack, node)
 
 		for len(stack) > 0 {
-			ln := len(stack)
-			node := stack[ln-1]
-			stack = stack[:ln-1]
+			stack = stack[:0]
+			nodeBuf.Reset()
 
-			tk := reflect.Interface
-			if node.Val.IsValid() {
-				tk = node.Val.Type().Kind()
+			node := nodeBuf.GetNode()
+			node.Val = src.Index(i)
+			if src.Index(i).Type().Kind() == reflect.Interface {
+				node.Val = src.Index(i).Elem()
 			}
-			var m Marshaler
+			node.PathMap = pathMap
+			stack = append(stack, node)
 
-			if tk == reflect.Ptr {
-				m = &ParquetPtr{}
-			} else if tk == reflect.Struct {
-				m = &ParquetStruct{}
-			} else if tk == reflect.Slice {
-				m = &ParquetSlice{schemaHandler: schemaHandler}
-			} else if tk == reflect.Map {
-				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
-				sele := schemaHandler.SchemaElements[schemaIndex]
-				if !sele.IsSetConvertedType() {
-					m = &ParquetMapStruct{schemaHandler: schemaHandler}
-				} else {
-					m = &ParquetMap{schemaHandler: schemaHandler}
-				}
-			} else {
-				table := res[node.PathMap.Path]
-				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
-				schema := schemaHandler.SchemaElements[schemaIndex]
-				var v interface{}
+			for len(stack) > 0 {
+				ln := len(stack)
+				node := stack[ln-1]
+				stack = stack[:ln-1]
+
+				tk := reflect.Interface
 				if node.Val.IsValid() {
-					v = node.Val.Interface()
+					tk = node.Val.Type().Kind()
 				}
-				table.Values = append(table.Values, types.InterfaceToParquetType(v, schema.Type))
-				table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
-				table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
-				continue
-			}
+				var m Marshaler
 
-			oldLen := len(stack)
-			stack = m.Marshal(node, nodeBuf, stack)
-			if len(stack) == oldLen {
-				path := node.PathMap.Path
-				index := schemaHandler.MapIndex[path]
-				numChildren := schemaHandler.SchemaElements[index].GetNumChildren()
-				if numChildren > int32(0) {
-					for key, table := range res {
-						if common.IsChildPath(path, key) {
-							table.Values = append(table.Values, nil)
-							table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
-							table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
-						}
+				if tk == reflect.Ptr || tk == reflect.UnsafePointer || tk == reflect.Interface || tk == reflect.Uintptr {
+					m = &ParquetPtr{}
+				} else if tk == reflect.Struct {
+					if isProto && node.Val.Type() == schema.ProtoTimestampType {
+						m = &ParquetTimestamp{}
+					} else {
+						m = &ParquetStruct{}
+					}
+				} else if tk == reflect.Slice || tk == reflect.Array {
+					m = &ParquetSlice{schemaHandler: schemaHandler}
+				} else if tk == reflect.Map {
+					schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
+					sele := schemaHandler.SchemaElements[schemaIndex]
+					if !sele.IsSetConvertedType() {
+						m = &ParquetMapStruct{schemaHandler: schemaHandler}
+					} else {
+						m = &ParquetMap{schemaHandler: schemaHandler}
 					}
 				} else {
-					table := res[path]
-					table.Values = append(table.Values, nil)
+					table := res[node.PathMap.Path]
+					schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
+					schemaDefinition := schemaHandler.SchemaElements[schemaIndex]
+					var v interface{}
+					if node.Val.IsValid() {
+						v = node.Val.Interface()
+					}
+					// special handling for the enum
+					if isProto && schemaDefinition.ConvertedType != nil && *schemaDefinition.ConvertedType == parquet.ConvertedType_ENUM {
+						v = node.Val.MethodByName(schema.ProtoStringMethodName).Call(nil)[0].Interface().(string)
+					}
+					table.Values = append(table.Values, types.InterfaceToParquetType(v, schemaDefinition.Type))
 					table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
 					table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+					continue
+				}
+
+				oldLen := len(stack)
+				stack = m.Marshal(node, nodeBuf, stack)
+				if len(stack) == oldLen {
+					path := node.PathMap.Path
+					index := schemaHandler.MapIndex[path]
+					numChildren := schemaHandler.SchemaElements[index].GetNumChildren()
+					if numChildren > int32(0) {
+						for key, table := range res {
+							if common.IsChildPath(path, key) {
+								table.Values = append(table.Values, nil)
+								table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+								table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+							}
+						}
+					} else {
+						table := res[path]
+						table.Values = append(table.Values, nil)
+						table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+						table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+					}
 				}
 			}
 		}

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -306,7 +306,7 @@ func MarshalStruct(srcInterface []interface{}, schemaHandler *schema.SchemaHandl
 				}
 				var m Marshaler
 
-				if tk == reflect.Ptr || tk == reflect.UnsafePointer || tk == reflect.Interface || tk == reflect.Uintptr {
+				if tk == reflect.Ptr || tk == reflect.UnsafePointer || tk == reflect.Uintptr {
 					m = &ParquetPtr{}
 				} else if tk == reflect.Struct {
 					if isProto && node.Val.Type() == schema.ProtoTimestampType {

--- a/marshal/proto.go
+++ b/marshal/proto.go
@@ -13,9 +13,10 @@ const ProtoNanosName = "Nanos"
 
 type ParquetTimestamp struct{}
 
+// Marshal the proto timestamp into milliseconds
 func (p *ParquetTimestamp) Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) []*Node {
-	mills := node.Val.FieldByName(ProtoSecondsName).Int()*1000 + node.Val.FieldByName(ProtoNanosName).Int()/(int64)(time.Millisecond)
-	node.Val = reflect.ValueOf(mills)
+	millis := node.Val.FieldByName(ProtoSecondsName).Int()*1000 + node.Val.FieldByName(ProtoNanosName).Int()/(int64)(time.Millisecond)
+	node.Val = reflect.ValueOf(millis)
 	stack = append(stack, node)
 	return stack
 }

--- a/marshal/proto.go
+++ b/marshal/proto.go
@@ -1,15 +1,11 @@
 package marshal
 
 import (
-	"errors"
 	"reflect"
 	"time"
 
-	"github.com/xitongsys/parquet-go/common"
 	"github.com/xitongsys/parquet-go/layout"
-	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/schema"
-	"github.com/xitongsys/parquet-go/types"
 )
 
 const ProtoSecondsName = "Seconds"
@@ -26,127 +22,5 @@ func (p *ParquetTimestamp) Marshal(node *Node, nodeBuf *NodeBufType, stack []*No
 
 // Convert the objects to table map. srcInterface is a slice of objects
 func MarshalProto(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New("unkown error")
-			}
-		}
-	}()
-
-	src := reflect.ValueOf(srcInterface)
-	res := setupTableMap(schemaHandler, len(srcInterface))
-	pathMap := schemaHandler.PathMap
-	nodeBuf := NewNodeBuf(1)
-
-	for i := 0; i < len(schemaHandler.SchemaElements); i++ {
-		schemaDefinition := schemaHandler.SchemaElements[i]
-		pathStr := schemaHandler.IndexMap[int32(i)]
-		numChildren := schemaDefinition.GetNumChildren()
-		if numChildren == 0 {
-			table := layout.NewEmptyTable()
-			table.Path = common.StrToPath(pathStr)
-			table.MaxDefinitionLevel, _ = schemaHandler.MaxDefinitionLevel(table.Path)
-			table.MaxRepetitionLevel, _ = schemaHandler.MaxRepetitionLevel(table.Path)
-			table.RepetitionType = schemaDefinition.GetRepetitionType()
-			table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
-			table.Info = schemaHandler.Infos[i]
-			// Pre-size tables under the assumption that they'll be filled.
-			table.Values = make([]interface{}, 0, len(srcInterface))
-			table.DefinitionLevels = make([]int32, 0, len(srcInterface))
-			table.RepetitionLevels = make([]int32, 0, len(srcInterface))
-			res[pathStr] = table
-		}
-	}
-
-	stack := make([]*Node, 0, 100)
-	for i := 0; i < len(srcInterface); i++ {
-		stack = stack[:0]
-		nodeBuf.Reset()
-
-		node := nodeBuf.GetNode()
-		node.Val = src.Index(i)
-		if src.Index(i).Type().Kind() == reflect.Interface {
-			node.Val = src.Index(i).Elem()
-		}
-		node.PathMap = pathMap
-		stack = append(stack, node)
-
-		for len(stack) > 0 {
-			ln := len(stack)
-			node := stack[ln-1]
-			stack = stack[:ln-1]
-
-			tk := reflect.Interface
-			if node.Val.IsValid() {
-				tk = node.Val.Type().Kind()
-			}
-			var m Marshaler
-
-			if tk == reflect.Ptr || tk == reflect.UnsafePointer || tk == reflect.Interface || tk == reflect.Uintptr {
-				m = &ParquetPtr{}
-			} else if tk == reflect.Struct {
-				if node.Val.Type() == schema.ProtoTimestampType {
-					m = &ParquetTimestamp{}
-				} else {
-					m = &ParquetStruct{}
-				}
-			} else if tk == reflect.Slice || tk == reflect.Array {
-				m = &ParquetSlice{schemaHandler: schemaHandler}
-			} else if tk == reflect.Map {
-				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
-				sele := schemaHandler.SchemaElements[schemaIndex]
-				if !sele.IsSetConvertedType() {
-					m = &ParquetMapStruct{schemaHandler: schemaHandler}
-				} else {
-					m = &ParquetMap{schemaHandler: schemaHandler}
-				}
-			} else {
-				table := res[node.PathMap.Path]
-				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
-				schemaDefinition := schemaHandler.SchemaElements[schemaIndex]
-				var v interface{}
-				if node.Val.IsValid() {
-					v = node.Val.Interface()
-				}
-				// special handling for the enum
-				if schemaDefinition.ConvertedType != nil && *schemaDefinition.ConvertedType == parquet.ConvertedType_ENUM {
-					v = node.Val.MethodByName(schema.ProtoStringMethodName).Call(nil)[0].Interface().(string)
-				}
-				table.Values = append(table.Values, types.InterfaceToParquetType(v, schemaDefinition.Type))
-				table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
-				table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
-				continue
-			}
-
-			oldLen := len(stack)
-			stack = m.Marshal(node, nodeBuf, stack)
-			if len(stack) == oldLen {
-				path := node.PathMap.Path
-				index := schemaHandler.MapIndex[path]
-				numChildren := schemaHandler.SchemaElements[index].GetNumChildren()
-				if numChildren > int32(0) {
-					for key, table := range res {
-						if common.IsChildPath(path, key) {
-							table.Values = append(table.Values, nil)
-							table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
-							table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
-						}
-					}
-				} else {
-					table := res[path]
-					table.Values = append(table.Values, nil)
-					table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
-					table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
-				}
-			}
-		}
-	}
-
-	return &res, nil
+	return MarshalStruct(srcInterface, schemaHandler, true)
 }

--- a/marshal/proto.go
+++ b/marshal/proto.go
@@ -1,0 +1,152 @@
+package marshal
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/xitongsys/parquet-go/common"
+	"github.com/xitongsys/parquet-go/layout"
+	"github.com/xitongsys/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+const ProtoSecondsName = "Seconds"
+const ProtoNanosName = "Nanos"
+
+type ParquetTimestamp struct{}
+
+func (p *ParquetTimestamp) Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) []*Node {
+	mills := node.Val.FieldByName(ProtoSecondsName).Int()*1000 + node.Val.FieldByName(ProtoNanosName).Int()/(int64)(time.Millisecond)
+	node.Val = reflect.ValueOf(mills)
+	stack = append(stack, node)
+	return stack
+}
+
+// Convert the objects to table map. srcInterface is a slice of objects
+func MarshalProto(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("unkown error")
+			}
+		}
+	}()
+
+	src := reflect.ValueOf(srcInterface)
+	res := setupTableMap(schemaHandler, len(srcInterface))
+	pathMap := schemaHandler.PathMap
+	nodeBuf := NewNodeBuf(1)
+
+	for i := 0; i < len(schemaHandler.SchemaElements); i++ {
+		schemaDefinition := schemaHandler.SchemaElements[i]
+		pathStr := schemaHandler.IndexMap[int32(i)]
+		numChildren := schemaDefinition.GetNumChildren()
+		if numChildren == 0 {
+			table := layout.NewEmptyTable()
+			table.Path = common.StrToPath(pathStr)
+			table.MaxDefinitionLevel, _ = schemaHandler.MaxDefinitionLevel(table.Path)
+			table.MaxRepetitionLevel, _ = schemaHandler.MaxRepetitionLevel(table.Path)
+			table.RepetitionType = schemaDefinition.GetRepetitionType()
+			table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
+			table.Info = schemaHandler.Infos[i]
+			// Pre-size tables under the assumption that they'll be filled.
+			table.Values = make([]interface{}, 0, len(srcInterface))
+			table.DefinitionLevels = make([]int32, 0, len(srcInterface))
+			table.RepetitionLevels = make([]int32, 0, len(srcInterface))
+			res[pathStr] = table
+		}
+	}
+
+	stack := make([]*Node, 0, 100)
+	for i := 0; i < len(srcInterface); i++ {
+		stack = stack[:0]
+		nodeBuf.Reset()
+
+		node := nodeBuf.GetNode()
+		node.Val = src.Index(i)
+		if src.Index(i).Type().Kind() == reflect.Interface {
+			node.Val = src.Index(i).Elem()
+		}
+		node.PathMap = pathMap
+		stack = append(stack, node)
+
+		for len(stack) > 0 {
+			ln := len(stack)
+			node := stack[ln-1]
+			stack = stack[:ln-1]
+
+			tk := reflect.Interface
+			if node.Val.IsValid() {
+				tk = node.Val.Type().Kind()
+			}
+			var m Marshaler
+
+			if tk == reflect.Ptr || tk == reflect.UnsafePointer || tk == reflect.Interface || tk == reflect.Uintptr {
+				m = &ParquetPtr{}
+			} else if tk == reflect.Struct {
+				if node.Val.Type() == schema.ProtoTimestampType {
+					m = &ParquetTimestamp{}
+				} else {
+					m = &ParquetStruct{}
+				}
+			} else if tk == reflect.Slice || tk == reflect.Array {
+				m = &ParquetSlice{schemaHandler: schemaHandler}
+			} else if tk == reflect.Map {
+				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
+				sele := schemaHandler.SchemaElements[schemaIndex]
+				if !sele.IsSetConvertedType() {
+					m = &ParquetMapStruct{schemaHandler: schemaHandler}
+				} else {
+					m = &ParquetMap{schemaHandler: schemaHandler}
+				}
+			} else {
+				table := res[node.PathMap.Path]
+				schemaIndex := schemaHandler.MapIndex[node.PathMap.Path]
+				schemaDefinition := schemaHandler.SchemaElements[schemaIndex]
+				var v interface{}
+				if node.Val.IsValid() {
+					v = node.Val.Interface()
+				}
+				// special handling for the enum
+				if schemaDefinition.ConvertedType != nil && *schemaDefinition.ConvertedType == parquet.ConvertedType_ENUM {
+					v = node.Val.MethodByName(schema.ProtoStringMethodName).Call(nil)[0].Interface().(string)
+				}
+				table.Values = append(table.Values, types.InterfaceToParquetType(v, schemaDefinition.Type))
+				table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+				table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+				continue
+			}
+
+			oldLen := len(stack)
+			stack = m.Marshal(node, nodeBuf, stack)
+			if len(stack) == oldLen {
+				path := node.PathMap.Path
+				index := schemaHandler.MapIndex[path]
+				numChildren := schemaHandler.SchemaElements[index].GetNumChildren()
+				if numChildren > int32(0) {
+					for key, table := range res {
+						if common.IsChildPath(path, key) {
+							table.Values = append(table.Values, nil)
+							table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+							table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+						}
+					}
+				} else {
+					table := res[path]
+					table.Values = append(table.Values, nil)
+					table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+					table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+				}
+			}
+		}
+	}
+
+	return &res, nil
+}

--- a/marshal/proto_test.go
+++ b/marshal/proto_test.go
@@ -1,0 +1,142 @@
+package marshal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xitongsys/parquet-go/schema"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type subElem struct {
+	Val string
+}
+
+type testNestedElem struct {
+	SubElem     subElem
+	SubPtr      *subElem
+	SubList     []subElem
+	SubRepeated []*subElem
+	// Marshal ok but not write since it doesn't have corresponding primitive type
+	EmptyElem     struct{}
+	EmptyPtr      *struct{}
+	EmptyList     []struct{}
+	EmptyRepeated []*struct{}
+}
+type JobStatus int32
+
+const (
+	JobStatus_JobStatus_UNSPECIFIED  JobStatus = 0
+	JobStatus_BLOCKED                JobStatus = 1
+	JobStatus_ENQUEUED               JobStatus = 2
+	JobStatus_RUNNING                JobStatus = 3
+	JobStatus_COMPLETED              JobStatus = 4
+	JobStatus_ERRORED                JobStatus = 5
+	JobStatus_CANCELLED              JobStatus = 6
+	JobStatus_UPSTREAM_NOT_PROCESSED JobStatus = 7
+)
+
+func (x JobStatus) Enum() *JobStatus {
+	p := new(JobStatus)
+	*p = x
+	return p
+}
+
+func (x JobStatus) String() string {
+	statusToName := map[int32]string{
+		0: "ASYNCJOBSTATUS_UNSPECIFIED",
+		1: "BLOCKED",
+		2: "ENQUEUED",
+		3: "RUNNING",
+		4: "COMPLETED",
+		5: "ERRORED",
+		6: "CANCELLED",
+		7: "UPSTREAM_NOT_PROCESSED",
+	}
+	return statusToName[int32(x)]
+}
+
+type ProtoMessage struct {
+	Timestamp timestamppb.Timestamp
+	Status    JobStatus
+	IntVal    int32
+}
+
+func TestMarsalProtoSpecific(t *testing.T) {
+	protoMessages := []interface{}{
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: 1000000}, Status: JobStatus_RUNNING, IntVal: 1},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: 1000000}, Status: JobStatus_ENQUEUED, IntVal: 2},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: 1000000}, Status: JobStatus_COMPLETED, IntVal: 3},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: 1000000}, Status: JobStatus_ERRORED, IntVal: 4},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: 1000000}, Status: JobStatus_CANCELLED, IntVal: 5},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: 1000000}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6},
+	}
+
+	schemaHandler, err := schema.NewSchemaHandlerFromProtoStruct(ProtoMessage{})
+	if err != nil {
+		t.Errorf("failed to get schema handler: %v", err)
+	}
+	tableMap, err := MarshalProto(protoMessages, schemaHandler)
+	if err != nil {
+		t.Errorf("failed to marshal values: %v", err)
+	}
+	assert.Equal(t, 3, len(schemaHandler.ValueColumns))
+	assert.Equal(t, 6, len((*tableMap)["Parquet_go_root\x01Timestamp"].Values))
+	assert.Equal(t, int64(1001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[0].(int64))
+	assert.Equal(t, int64(2001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[1].(int64))
+	assert.Equal(t, int64(3001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[2].(int64))
+	assert.Equal(t, int64(4001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[3].(int64))
+	assert.Equal(t, int64(5001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[4].(int64))
+	assert.Equal(t, int64(6001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[5].(int64))
+	assert.Equal(t, 6, len((*tableMap)["Parquet_go_root\x01Status"].Values))
+	assert.Equal(t, "RUNNING", (*tableMap)["Parquet_go_root\x01Status"].Values[0].(string))
+	assert.Equal(t, "ENQUEUED", (*tableMap)["Parquet_go_root\x01Status"].Values[1].(string))
+	assert.Equal(t, "COMPLETED", (*tableMap)["Parquet_go_root\x01Status"].Values[2].(string))
+	assert.Equal(t, "ERRORED", (*tableMap)["Parquet_go_root\x01Status"].Values[3].(string))
+	assert.Equal(t, "CANCELLED", (*tableMap)["Parquet_go_root\x01Status"].Values[4].(string))
+	assert.Equal(t, "UPSTREAM_NOT_PROCESSED", (*tableMap)["Parquet_go_root\x01Status"].Values[5].(string))
+
+	fmt.Println(tableMap)
+}
+
+func TestMarshalTestNestedElem(t *testing.T) {
+	testNestedElems := []interface{}{
+		testNestedElem{},
+		testNestedElem{SubElem: subElem{Val: "hi"}},
+		testNestedElem{SubPtr: &subElem{Val: "hi"}},
+		testNestedElem{SubList: []subElem{}},
+		testNestedElem{SubList: []subElem{{Val: "hi"}}},
+		testNestedElem{SubList: []subElem{{Val: "hi"}, {}, {Val: "there"}}},
+		testNestedElem{SubRepeated: []*subElem{}},
+		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}}},
+		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}, nil, {Val: "there"}}},
+		testNestedElem{EmptyPtr: &struct{}{}},
+		testNestedElem{EmptyList: []struct{}{}},
+		testNestedElem{EmptyList: []struct{}{{}}},
+		testNestedElem{EmptyList: []struct{}{{}, {}}},
+		testNestedElem{EmptyRepeated: []*struct{}{}},
+		testNestedElem{EmptyRepeated: []*struct{}{{}}},
+		testNestedElem{EmptyRepeated: []*struct{}{{}, nil, {}}},
+	}
+	schemaHandler, err := schema.NewSchemaHandlerFromProtoStruct(testNestedElem{})
+	if err != nil {
+		t.Errorf("failed to get schema handler: %v", err)
+	}
+	tableMap, err := MarshalProto(testNestedElems, schemaHandler)
+	if err != nil {
+		t.Errorf("failed to marshal values: %v", err)
+	}
+	assert.Equal(t, 8, len(schemaHandler.ValueColumns))
+	for i := 0; i < 18; i++ {
+		assert.Equal(t, nil, (*tableMap)["Parquet_go_root\x01EmptyRepeated\x01List\x01Element"].Values[i])
+	}
+	// There are total 16 objects in the list
+	assert.Equal(t, 16, len((*tableMap)["Parquet_go_root\x01SubElem\x01Val"].Values))
+	assert.Equal(t, "hi", (*tableMap)["Parquet_go_root\x01SubElem\x01Val"].Values[1].(string))
+	// There is one list with 3 values which increase total values to 16+2
+	assert.Equal(t, 18, len((*tableMap)["Parquet_go_root\x01SubList\x01List\x01Element\x01Val"].Values))
+	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)["Parquet_go_root\x01SubList\x01List\x01Element\x01Val"].DefinitionLevels)
+	assert.Equal(t, 18, len((*tableMap)["Parquet_go_root\x01SubRepeated\x01List\x01Element\x01Val"].Values))
+	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 0, 0, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)["Parquet_go_root\x01SubRepeated\x01List\x01Element\x01Val"].DefinitionLevels)
+}

--- a/marshal/proto_test.go
+++ b/marshal/proto_test.go
@@ -3,6 +3,7 @@ package marshal
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xitongsys/parquet-go/schema"
@@ -45,7 +46,7 @@ func (x JobStatus) Enum() *JobStatus {
 
 func (x JobStatus) String() string {
 	statusToName := map[int32]string{
-		0: "ASYNCJOBSTATUS_UNSPECIFIED",
+		0: "JOBSTATUS_UNSPECIFIED",
 		1: "BLOCKED",
 		2: "ENQUEUED",
 		3: "RUNNING",
@@ -65,12 +66,14 @@ type ProtoMessage struct {
 
 func TestMarsalProtoSpecific(t *testing.T) {
 	protoMessages := []interface{}{
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: 1000000}, Status: JobStatus_RUNNING, IntVal: 1},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: 1000000}, Status: JobStatus_ENQUEUED, IntVal: 2},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: 1000000}, Status: JobStatus_COMPLETED, IntVal: 3},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: 1000000}, Status: JobStatus_ERRORED, IntVal: 4},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: 1000000}, Status: JobStatus_CANCELLED, IntVal: 5},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: 1000000}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: int32(time.Millisecond)}, Status: JobStatus_RUNNING, IntVal: 1},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: int32(time.Millisecond)}, Status: JobStatus_ENQUEUED, IntVal: 2},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: int32(time.Millisecond)}, Status: JobStatus_COMPLETED, IntVal: 3},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: int32(time.Millisecond)}, Status: JobStatus_ERRORED, IntVal: 4},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: int32(time.Millisecond)}, Status: JobStatus_CANCELLED, IntVal: 5},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: int32(time.Millisecond)}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: int32(time.Millisecond)}, Status: JobStatus_BLOCKED, IntVal: 6},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: int32(time.Millisecond)}, Status: JobStatus_JobStatus_UNSPECIFIED, IntVal: 7},
 	}
 
 	schemaHandler, err := schema.NewSchemaHandlerFromProtoStruct(ProtoMessage{})
@@ -81,36 +84,44 @@ func TestMarsalProtoSpecific(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to marshal values: %v", err)
 	}
+	const timestampField = "Parquet_go_root\x01Timestamp"
+	const statusField = "Parquet_go_root\x01Status"
 	assert.Equal(t, 3, len(schemaHandler.ValueColumns))
-	assert.Equal(t, 6, len((*tableMap)["Parquet_go_root\x01Timestamp"].Values))
-	assert.Equal(t, int64(1001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[0].(int64))
-	assert.Equal(t, int64(2001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[1].(int64))
-	assert.Equal(t, int64(3001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[2].(int64))
-	assert.Equal(t, int64(4001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[3].(int64))
-	assert.Equal(t, int64(5001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[4].(int64))
-	assert.Equal(t, int64(6001), (*tableMap)["Parquet_go_root\x01Timestamp"].Values[5].(int64))
-	assert.Equal(t, 6, len((*tableMap)["Parquet_go_root\x01Status"].Values))
-	assert.Equal(t, "RUNNING", (*tableMap)["Parquet_go_root\x01Status"].Values[0].(string))
-	assert.Equal(t, "ENQUEUED", (*tableMap)["Parquet_go_root\x01Status"].Values[1].(string))
-	assert.Equal(t, "COMPLETED", (*tableMap)["Parquet_go_root\x01Status"].Values[2].(string))
-	assert.Equal(t, "ERRORED", (*tableMap)["Parquet_go_root\x01Status"].Values[3].(string))
-	assert.Equal(t, "CANCELLED", (*tableMap)["Parquet_go_root\x01Status"].Values[4].(string))
-	assert.Equal(t, "UPSTREAM_NOT_PROCESSED", (*tableMap)["Parquet_go_root\x01Status"].Values[5].(string))
+	assert.Equal(t, 8, len((*tableMap)[timestampField].Values))
+	assert.Equal(t, int64(1001), (*tableMap)[timestampField].Values[0].(int64))
+	assert.Equal(t, int64(2001), (*tableMap)[timestampField].Values[1].(int64))
+	assert.Equal(t, int64(3001), (*tableMap)[timestampField].Values[2].(int64))
+	assert.Equal(t, int64(4001), (*tableMap)[timestampField].Values[3].(int64))
+	assert.Equal(t, int64(5001), (*tableMap)[timestampField].Values[4].(int64))
+	assert.Equal(t, int64(6001), (*tableMap)[timestampField].Values[5].(int64))
+	assert.Equal(t, int64(5001), (*tableMap)[timestampField].Values[6].(int64))
+	assert.Equal(t, int64(5001), (*tableMap)[timestampField].Values[7].(int64))
+	assert.Equal(t, 8, len((*tableMap)[statusField].Values))
+	assert.Equal(t, "RUNNING", (*tableMap)[statusField].Values[0].(string))
+	assert.Equal(t, "ENQUEUED", (*tableMap)[statusField].Values[1].(string))
+	assert.Equal(t, "COMPLETED", (*tableMap)[statusField].Values[2].(string))
+	assert.Equal(t, "ERRORED", (*tableMap)[statusField].Values[3].(string))
+	assert.Equal(t, "CANCELLED", (*tableMap)[statusField].Values[4].(string))
+	assert.Equal(t, "UPSTREAM_NOT_PROCESSED", (*tableMap)[statusField].Values[5].(string))
+	assert.Equal(t, "BLOCKED", (*tableMap)[statusField].Values[6].(string))
+	assert.Equal(t, "JOBSTATUS_UNSPECIFIED", (*tableMap)[statusField].Values[7].(string))
 
 	fmt.Println(tableMap)
 }
 
 func TestMarshalTestNestedElem(t *testing.T) {
+	subElemHi := subElem{Val: "hi"}
+	subElemThere := subElem{Val: "there"}
 	testNestedElems := []interface{}{
 		testNestedElem{},
-		testNestedElem{SubElem: subElem{Val: "hi"}},
-		testNestedElem{SubPtr: &subElem{Val: "hi"}},
+		testNestedElem{SubElem: subElemHi},
+		testNestedElem{SubPtr: &subElemHi},
 		testNestedElem{SubList: []subElem{}},
-		testNestedElem{SubList: []subElem{{Val: "hi"}}},
-		testNestedElem{SubList: []subElem{{Val: "hi"}, {}, {Val: "there"}}},
+		testNestedElem{SubList: []subElem{subElemHi}},
+		testNestedElem{SubList: []subElem{subElemHi, {}, subElemThere}},
 		testNestedElem{SubRepeated: []*subElem{}},
-		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}}},
-		testNestedElem{SubRepeated: []*subElem{{Val: "hi"}, nil, {Val: "there"}}},
+		testNestedElem{SubRepeated: []*subElem{&subElemHi}},
+		testNestedElem{SubRepeated: []*subElem{&subElemHi, nil, &subElemThere}},
 		testNestedElem{EmptyPtr: &struct{}{}},
 		testNestedElem{EmptyList: []struct{}{}},
 		testNestedElem{EmptyList: []struct{}{{}}},
@@ -131,12 +142,15 @@ func TestMarshalTestNestedElem(t *testing.T) {
 	for i := 0; i < 18; i++ {
 		assert.Equal(t, nil, (*tableMap)["Parquet_go_root\x01EmptyRepeated\x01List\x01Element"].Values[i])
 	}
+	const subElemeField = "Parquet_go_root\x01SubElem\x01Val"
 	// There are total 16 objects in the list
-	assert.Equal(t, 16, len((*tableMap)["Parquet_go_root\x01SubElem\x01Val"].Values))
-	assert.Equal(t, "hi", (*tableMap)["Parquet_go_root\x01SubElem\x01Val"].Values[1].(string))
+	assert.Equal(t, 16, len((*tableMap)[subElemeField].Values))
+	assert.Equal(t, "hi", (*tableMap)[subElemeField].Values[1].(string))
 	// There is one list with 3 values which increase total values to 16+2
-	assert.Equal(t, 18, len((*tableMap)["Parquet_go_root\x01SubList\x01List\x01Element\x01Val"].Values))
-	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)["Parquet_go_root\x01SubList\x01List\x01Element\x01Val"].DefinitionLevels)
-	assert.Equal(t, 18, len((*tableMap)["Parquet_go_root\x01SubRepeated\x01List\x01Element\x01Val"].Values))
-	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 0, 0, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)["Parquet_go_root\x01SubRepeated\x01List\x01Element\x01Val"].DefinitionLevels)
+	const sublistElemField = "Parquet_go_root\x01SubList\x01List\x01Element\x01Val"
+	const repeatedElemField = "Parquet_go_root\x01SubRepeated\x01List\x01Element\x01Val"
+	assert.Equal(t, 18, len((*tableMap)[sublistElemField].Values))
+	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)[sublistElemField].DefinitionLevels)
+	assert.Equal(t, 18, len((*tableMap)[repeatedElemField].Values))
+	assert.ElementsMatch(t, []int32{0, 0, 0, 0, 0, 0, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0}, (*tableMap)[repeatedElemField].DefinitionLevels)
 }

--- a/writer/proto.go
+++ b/writer/proto.go
@@ -1,0 +1,23 @@
+package writer
+
+import (
+	"fmt"
+
+	"github.com/xitongsys/parquet-go/marshal"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/source"
+)
+
+// Pass the obj as the go struct object
+func NewParquetWriterFromProto(pFile source.ParquetFile, obj interface{}, np int64) (*ParquetWriter, error) {
+	schemaHandler, err := schema.NewSchemaHandlerFromProtoStruct(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate schema handler: %v", err)
+	}
+	parquetWriter, err := NewParquetWriter(pFile, schemaHandler, np)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create writer %v", err)
+	}
+	parquetWriter.MarshalFunc = marshal.MarshalProto
+	return parquetWriter, nil
+}


### PR DESCRIPTION
### Description

<!-- Please write a standard PR description here, and link to the plant that describes the broader context of this code change. Use [title][url] to create a link. -->

- Special handling for the Enum(convert to string) and Timestamp(convert to int64 mills) proto specific use in marshal
- Fix a few minor issues in the recursive handling slice 
- Add two integration test file testelement_write.go and proto_write.go

There are many lines of change is about integration test to build binary and run local to create parquet file. 
The actual change need review is 

- marshal/marshal.go (mainly refactor to pass additional flag isPoroto to make it reusable.)
- marshal/proto.go
- writer/proto.go

[Log Analyzer Framework](https://docs.google.com/document/d/1dZGKIlg3sqaNgDupLJ1tiroQvEoLuZXxg81GFJ16vYI/edit)

### How this code was tested
<!-- Add unit/regression/scenario/manual tests used to test this feature -->
unit test.

In the example folder, there is different integration testing files. There are two files added.
testelement_write.go and proto_write.go
How to test

1. cd example
2. go build proto_write.go
3. ./proto_write
4. parquet-tools show output/proto_message.parquet (requires install parquet-tools by pip3 install parquet-tools)
5. validate the data

+----------------------------+------------------------+----------+
| Timestamp                  | Status                 |   IntVal |
|----------------------------+------------------------+----------|
| 1970-01-01 00:00:01.001000 | RUNNING                |        1 |
| 1970-01-01 00:00:02.001000 | ENQUEUED               |        2 |
| 1970-01-01 00:00:03.001000 | COMPLETED              |        3 |
| 1970-01-01 00:00:04.001000 | ERRORED                |        4 |
| 1970-01-01 00:00:05.001000 | CANCELLED              |        5 |
| 1970-01-01 00:00:06.001000 | UPSTREAM_NOT_PROCESSED |        6 |
+----------------------------+------------------------+----------+

### Changelog
<!-- see link for more details/examples: https://docs.google.com/document/d/1GBHOgi1jsQgMqWfHg_2t1XUu5Bv9eUfGGQYQoKxKz1o
and this header for valid products/categories: https://docs.google.com/document/d/1GBHOgi1jsQgMqWfHg_2t1XUu5Bv9eUfGGQYQoKxKz1o/edit#heading=h.xjo5nf8ygjdh -->
+no-changelog

### Issues fixed (optional)
close #182667