### PR TITLE
[Ursa Log Analyzer] Generate the tags and schema handler for proto struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ example/output/*
 
 # exception to the rule
 !example/output/.gitkeep
+
+.vscode/*

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.15
 	github.com/stretchr/testify v1.8.0
 	github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0
+	google.golang.org/protobuf v1.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
+google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/schema/proto.go
+++ b/schema/proto.go
@@ -1,0 +1,386 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/xitongsys/parquet-go/common"
+	"github.com/xitongsys/parquet-go/parquet"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	ParquetFieldName = "name"
+
+	ParquetType               = "type"
+	ParquetConvertedType      = "convertedtype"
+	ParquetValueType          = "valuetype"
+	ParquetKeyType            = "keytype"
+	ParquetKeyConvertedType   = "keyconvertedtype"
+	ParquetValueConvertedType = "valueconvertedtype"
+
+	ParquetTypeBoolean           = "BOOLEAN"
+	ParquetTypeInt32             = "INT32"
+	ParquetTypeInt64             = "INT64"
+	ParquetTypeInt96             = "INT96"
+	ParquetTypeFloat             = "FLOAT"
+	ParquetTypeDouble            = "DOUBLE"
+	ParquetTypeByteArray         = "BYTE_ARRAY"
+	ParquetTypeFixedLenByteArray = "FIXED_LEN_BYTE_ARRAY"
+
+	ParquetTypeMap    = "MAP"
+	ParquetTypeList   = "LIST"
+	ParquetTypeStruct = "STRUCT"
+
+	ConvertedTypeUtf8            = "UTF8"
+	ConvertedTypeMap             = "MAP"
+	ConvertedTypeList            = "LIST"
+	ConvertedTypeEnum            = "ENUM"
+	ConvertedTypeDecimal         = "DECIMAL"
+	ConvertedTypeDate            = "DATE"
+	ConvertedTypeTimeMills       = "TIME_MILLIS"
+	ConvertedTypeTimeMicros      = "TIME_MICROS"
+	ConvertedTypeTimestampMills  = "TIMESTAMP_MILLIS"
+	ConvertedTypeTimestampMicros = "TIMESTAMP_MICROS"
+	ConvertedTypeUnit8           = "UINT_8"
+	ConvertedTypeUnint16         = "UINT_16"
+	ConvertedTypeUnint32         = "UINT_32"
+	ConvertedTypeUnint64         = "UINT_64"
+	ConvertedTypeInt8            = "INT_8"
+	ConvertedTypeInt16           = "INT_16"
+	ConvertedTypeInt32           = "INT_32"
+	ConvertedTypeInt64           = "INT_64"
+	ConvertedTypeJson            = "JSON"
+	ConvertedTypeBson            = "BSON"
+	ConvertedTypeInterval        = "INTERVAL"
+
+	ProtoEnumMethodName   = "Enum"
+	ProtoStringMethodName = "String"
+)
+
+var ProtoTimestampType = reflect.TypeOf(timestamppb.Timestamp{})
+
+func IsPrimitiveParquetType(tp string) bool {
+	switch tp {
+	case ParquetTypeBoolean,
+		ParquetTypeInt32,
+		ParquetTypeInt64,
+		ParquetTypeInt96,
+		ParquetTypeFloat,
+		ParquetTypeDouble,
+		ParquetTypeByteArray,
+		ParquetTypeFixedLenByteArray:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsPrimitiveGoTypeKind(kind reflect.Kind) bool {
+	switch kind {
+	case
+		reflect.Bool,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Int,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uint,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.String:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsPointerGoTypeKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Pointer, reflect.UnsafePointer, reflect.Uintptr, reflect.Interface:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsPrimitiveOrPointerGoKind(kind reflect.Kind) bool {
+	return IsPointerGoTypeKind(kind) || IsPrimitiveGoTypeKind(kind)
+}
+
+func IsProtoInternalField(name string) bool {
+	switch name {
+	case "state", "sizeCache", "unknownFields":
+		return true
+	default:
+		return false
+
+	}
+}
+
+func GetDefinedTypeTag(tp reflect.Type) (tags map[string]string, err error) {
+	tags = make(map[string]string)
+
+	switch tp.Kind() {
+	case reflect.Bool:
+		tags[ParquetType] = ParquetTypeBoolean
+	case reflect.Int8:
+		tags[ParquetType] = ParquetTypeInt32
+		tags[ParquetConvertedType] = ConvertedTypeInt8
+	case reflect.Int16:
+		tags[ParquetType] = ParquetTypeInt32
+		tags[ParquetConvertedType] = ConvertedTypeInt16
+	case reflect.Int32:
+		// speical handling for the proto enum generated constant, it checks Enum() method generated. It's not ideal but no better way to do it.
+		if _, exists := tp.MethodByName(ProtoEnumMethodName); exists {
+			tags[ParquetType] = ParquetTypeByteArray
+			tags[ParquetConvertedType] = ConvertedTypeEnum
+		} else {
+			tags[ParquetType] = ParquetTypeInt32
+		}
+	case reflect.Int64:
+		tags[ParquetType] = ParquetTypeInt64
+	case reflect.Int:
+		tags[ParquetType] = ParquetTypeInt64
+	case reflect.Uint8:
+		tags[ParquetType] = ParquetTypeInt32
+		tags[ParquetConvertedType] = ConvertedTypeUnit8
+	case reflect.Uint16:
+		tags[ParquetType] = ParquetTypeInt32
+		tags[ParquetConvertedType] = ConvertedTypeUnint16
+	case reflect.Uint32:
+		tags[ParquetType] = ParquetTypeInt32
+		tags[ParquetConvertedType] = ConvertedTypeUnint32
+	case reflect.Uint64:
+		tags[ParquetType] = ParquetTypeInt64
+		tags[ParquetConvertedType] = ConvertedTypeUnint64
+	case reflect.Uint:
+		tags[ParquetType] = ParquetTypeInt64
+		tags[ParquetConvertedType] = ConvertedTypeUnint64
+	case reflect.Float32:
+		tags[ParquetType] = ParquetTypeFloat
+	case reflect.Float64:
+		tags[ParquetType] = ParquetTypeDouble
+	case reflect.String:
+		tags[ParquetType] = ParquetTypeByteArray
+	case reflect.Pointer, reflect.UnsafePointer, reflect.Uintptr, reflect.Interface:
+		tags, err = GetDefinedTypeTag(tp.Elem())
+	case reflect.Array, reflect.Slice:
+		tags, err = getListTag(tp)
+	case reflect.Map:
+		tags, err = getMapTag(tp)
+	case reflect.Struct:
+		// do nothing since the struct tag is not needed in schema generation
+	default:
+		return nil, fmt.Errorf("Type %s is not supported in generating tags.", tp)
+	}
+	return
+}
+
+// Generate the tag for the struct field when there is no predefined tag
+func GenerateFieldTag(field reflect.StructField) (tagString string, err error) {
+	tags, err := GetDefinedTypeTag(field.Type)
+	if err != nil {
+		return "", err
+	}
+	tags[ParquetFieldName] = field.Name
+	return getTagStringFromTags(tags), nil
+}
+
+func getTagStringFromTags(tags map[string]string) string {
+	var pairs []string
+	for key, value := range tags {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
+	}
+	return strings.Join(pairs, ", ")
+}
+
+func getMapTag(tp reflect.Type) (tags map[string]string, err error) {
+	tags = make(map[string]string)
+	tags[ParquetType] = ParquetTypeMap
+	tags[ParquetConvertedType] = ParquetTypeMap
+	if IsPrimitiveOrPointerGoKind(tp.Key().Kind()) {
+		elementTags, elementErr := GetDefinedTypeTag(tp.Key())
+		if elementErr != nil {
+			return nil, elementErr
+		}
+		if elementType, exists := elementTags[ParquetType]; exists && IsPrimitiveParquetType(elementType) {
+			tags[ParquetKeyType] = elementType
+			if elementConvertedType, exists := elementTags[ParquetConvertedType]; exists {
+				tags[ParquetKeyConvertedType] = elementConvertedType
+			}
+		}
+	}
+	if IsPrimitiveOrPointerGoKind(tp.Elem().Kind()) {
+		elementTags, elementErr := GetDefinedTypeTag(tp.Elem())
+		if elementErr != nil {
+			return nil, elementErr
+		}
+		if elementType, exists := elementTags[ParquetType]; exists && IsPrimitiveParquetType(elementType) {
+			tags[ParquetValueType] = elementType
+			if elementConvertedType, exists := elementTags[ParquetConvertedType]; exists {
+				tags[ParquetValueConvertedType] = elementConvertedType
+			}
+		}
+	}
+	return
+}
+
+func getListTag(tp reflect.Type) (tags map[string]string, err error) {
+	tags = make(map[string]string)
+	tags[ParquetType] = ParquetTypeList
+	tags[ParquetConvertedType] = ParquetTypeList
+	if IsPrimitiveOrPointerGoKind(tp.Elem().Kind()) {
+		elementTags, elementErr := GetDefinedTypeTag(tp.Elem())
+		if elementErr != nil {
+			return nil, elementErr
+		}
+		if elementType, exists := elementTags[ParquetType]; exists && IsPrimitiveParquetType(elementType) {
+			tags[ParquetValueType] = elementType
+			if elementConvertedType, exists := elementTags[ParquetConvertedType]; exists {
+				tags[ParquetValueConvertedType] = elementConvertedType
+			}
+		}
+	}
+	return
+}
+
+// Speical handling for the timestamp schema to convert it as millis as one int64 number instead of keeping it as struct.
+func generateSchemaTimestamp(item *Item) (*parquet.SchemaElement, *common.Tag, error) {
+	item.Info.Type = ParquetTypeInt64
+	item.Info.ConvertedType = ConvertedTypeTimestampMills
+	schema, err := common.NewSchemaElementFromTagMap(item.Info)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate schema for timestamp: %v", err)
+	}
+	newInfo := common.NewTag()
+	common.DeepCopy(item.Info, newInfo)
+	return schema, newInfo, nil
+}
+
+func NewSchemaHandlerFromProtoStruct(obj interface{}) (sh *SchemaHandler, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("error occurred")
+			}
+		}
+	}()
+
+	ot := reflect.TypeOf(obj)
+	if ot.Kind() == reflect.Pointer {
+		ot = ot.Elem()
+	}
+	item := NewItem()
+	item.GoType = ot
+	item.Info.InName = "Parquet_go_root"
+	item.Info.ExName = "parquet_go_root"
+	item.Info.RepetitionType = parquet.FieldRepetitionType_REQUIRED
+
+	stack := make([]*Item, 1)
+	stack[0] = item
+	schemaElements := make([]*parquet.SchemaElement, 0)
+	infos := make([]*common.Tag, 0)
+
+	for len(stack) > 0 {
+		ln := len(stack)
+		item = stack[ln-1]
+		stack = stack[:ln-1]
+		var newInfo *common.Tag
+
+		if item.GoType.Kind() == reflect.Struct {
+			if item.GoType == ProtoTimestampType {
+				schema, newInfo, err := generateSchemaTimestamp(item)
+				if err != nil {
+					return nil, err
+				}
+				schemaElements = append(schemaElements, schema)
+				infos = append(infos, newInfo)
+				continue
+			}
+			schema := parquet.NewSchemaElement()
+			schema.Name = item.Info.InName
+			schema.RepetitionType = &item.Info.RepetitionType
+			numField := int32(item.GoType.NumField())
+			schemaElements = append(schemaElements, schema)
+
+			newInfo = common.NewTag()
+			common.DeepCopy(item.Info, newInfo)
+			numChildren := int32(0)
+			infos = append(infos, newInfo)
+
+			for i := int(numField - 1); i >= 0; i-- {
+				f := item.GoType.Field(i)
+				if IsProtoInternalField(f.Name) {
+					continue
+				}
+				tagStr, err := GenerateFieldTag(f)
+				if err != nil {
+					return nil, err
+				}
+				newItem, err := generateSchemaForStructField(f, tagStr)
+				if err != nil {
+					return nil, err
+				}
+				stack = append(stack, newItem)
+				numChildren++
+			}
+			schema.NumChildren = &numChildren
+		} else if (item.GoType.Kind() == reflect.Slice || item.GoType.Kind() == reflect.Array) &&
+			item.Info.RepetitionType != parquet.FieldRepetitionType_REPEATED {
+			// special handling for the nested slice, the value type cannot be prvoided through the regular tag since it only has one layer deep
+			if item.Info.ValueType == "" {
+				tags, err := GetDefinedTypeTag(item.GoType.Elem())
+				if err != nil {
+					return nil, err
+				}
+				item.Info.ValueType = tags[ParquetType]
+				item.Info.ValueConvertedType = tags[ParquetConvertedType]
+			}
+			stack, schemaElements, infos = generateSchemaForSlice(item, stack, schemaElements, infos)
+		} else if item.GoType.Kind() == reflect.Slice &&
+			item.Info.RepetitionType == parquet.FieldRepetitionType_REPEATED {
+			newItem := NewItem()
+			newItem.Info = item.Info
+			newItem.GoType = item.GoType.Elem()
+			stack = append(stack, newItem)
+		} else if IsPointerGoTypeKind(item.GoType.Kind()) {
+			item.GoType = item.GoType.Elem()
+			stack = append(stack, item)
+		} else if item.GoType.Kind() == reflect.Map {
+			stack, schemaElements, infos = generateSchemaForMap(item, stack, schemaElements, infos)
+		} else {
+			if item.Info.Type == "" {
+				tags, err := GetDefinedTypeTag(item.GoType)
+				if err != nil {
+					return nil, err
+				}
+				item.Info.Type = tags[ParquetType]
+			}
+			schema, err := common.NewSchemaElementFromTagMap(item.Info)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create schema from tag map: %s", err.Error())
+			}
+			schemaElements = append(schemaElements, schema)
+			newInfo = common.NewTag()
+			common.DeepCopy(item.Info, newInfo)
+			infos = append(infos, newInfo)
+		}
+	}
+
+	res := NewSchemaHandlerFromSchemaList(schemaElements)
+	res.Infos = infos
+	res.CreateInExMap()
+	return res, nil
+}

--- a/schema/proto_test.go
+++ b/schema/proto_test.go
@@ -14,7 +14,7 @@ import (
 type JobStatus int32
 
 const (
-	JobStatus_JobStatus_UNSPECIFIED  JobStatus = 0
+	JobStatus_UNSPECIFIED            JobStatus = 0
 	JobStatus_BLOCKED                JobStatus = 1
 	JobStatus_ENQUEUED               JobStatus = 2
 	JobStatus_RUNNING                JobStatus = 3
@@ -61,9 +61,7 @@ func TestProtoSpecificSchema(t *testing.T) {
 	assert.Equal(t, parquet.Type_BYTE_ARRAY, *schemaHandler.SchemaElements[2].Type)
 	assert.Equal(t, parquet.ConvertedType_ENUM, *schemaHandler.SchemaElements[2].ConvertedType)
 	assert.Equal(t, parquet.Type_INT32, *schemaHandler.SchemaElements[3].Type)
-	if schemaHandler.SchemaElements[3].ConvertedType != nil {
-		t.Errorf("primitive type int32 should not have converted type")
-	}
+	assert.Nil(t, schemaHandler.SchemaElements[3].ConvertedType)
 }
 
 func TestNewSchemaHandlerFromProtStruct(t *testing.T) {
@@ -108,8 +106,8 @@ func TestNewSchemaHandlerFromProtStruct(t *testing.T) {
 func TestTagGeneration(t *testing.T) {
 	expected := make(map[string]*common.Tag)
 	expected["Sex"], _ = common.StringToTag("name=Sex, type=BOOLEAN")
-	expected["Info"], _ = common.StringToTag("type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, valuetype=BYTE_ARRAY, name=Info")
-	expected["Classes"], _ = common.StringToTag("type=LIST, convertedtype=LIST, name=Classes")
+	expected["Info"], _ = common.StringToTag("type=MAP, keytype=BYTE_ARRAY, valuetype=BYTE_ARRAY, name=Info")
+	expected["Classes"], _ = common.StringToTag("type=LIST, name=Classes")
 	expected["Age"], _ = common.StringToTag("type=INT64, name=Age")
 	expected["Name"], _ = common.StringToTag("type=BYTE_ARRAY, name=Name")
 

--- a/schema/proto_test.go
+++ b/schema/proto_test.go
@@ -1,0 +1,128 @@
+package schema
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xitongsys/parquet-go/common"
+	"github.com/xitongsys/parquet-go/parquet"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type JobStatus int32
+
+const (
+	JobStatus_JobStatus_UNSPECIFIED  JobStatus = 0
+	JobStatus_BLOCKED                JobStatus = 1
+	JobStatus_ENQUEUED               JobStatus = 2
+	JobStatus_RUNNING                JobStatus = 3
+	JobStatus_COMPLETED              JobStatus = 4
+	JobStatus_ERRORED                JobStatus = 5
+	JobStatus_CANCELLED              JobStatus = 6
+	JobStatus_UPSTREAM_NOT_PROCESSED JobStatus = 7
+)
+
+func (x JobStatus) Enum() *JobStatus {
+	p := new(JobStatus)
+	*p = x
+	return p
+}
+
+type ClassNoTag struct {
+	Name   string
+	Number int
+	Score  string
+}
+
+type StudentNoTag struct {
+	Name    string
+	Age     int
+	Classes []*ClassNoTag
+	Info    *map[string]*string
+	Sex     *bool
+}
+
+type ProtoMessage struct {
+	Timestamp timestamppb.Timestamp
+	Status    JobStatus
+	IntVal    int32
+}
+
+func TestProtoSpecificSchema(t *testing.T) {
+	schemaHandler, err := NewSchemaHandlerFromProtoStruct(new(ProtoMessage))
+	if err != nil {
+		t.Errorf("failed to generate schema handler: %v", err)
+	}
+	assert.Equal(t, 3, len(schemaHandler.ValueColumns))
+	assert.Equal(t, parquet.Type_INT64, *schemaHandler.SchemaElements[1].Type)
+	assert.Equal(t, parquet.ConvertedType_TIMESTAMP_MILLIS, *schemaHandler.SchemaElements[1].ConvertedType)
+	assert.Equal(t, parquet.Type_BYTE_ARRAY, *schemaHandler.SchemaElements[2].Type)
+	assert.Equal(t, parquet.ConvertedType_ENUM, *schemaHandler.SchemaElements[2].ConvertedType)
+	assert.Equal(t, parquet.Type_INT32, *schemaHandler.SchemaElements[3].Type)
+	if schemaHandler.SchemaElements[3].ConvertedType != nil {
+		t.Errorf("primitive type int32 should not have converted type")
+	}
+}
+
+func TestNewSchemaHandlerFromProtStruct(t *testing.T) {
+	schemaHandler, err := NewSchemaHandlerFromProtoStruct(new(StudentNoTag))
+	if err != nil {
+		t.Errorf("failed to generate schema handler: %v", err)
+	}
+	assert.Equal(t, 14, len(schemaHandler.SchemaElements))
+	assert.Equal(t, 8, len(schemaHandler.ValueColumns))
+	expectedValues := []string{
+		"Parquet_go_root\x01Name",
+		"Parquet_go_root\x01Age",
+		"Parquet_go_root\x01Classes\x01List\x01Element\x01Name",
+		"Parquet_go_root\x01Classes\x01List\x01Element\x01Number",
+		"Parquet_go_root\x01Classes\x01List\x01Element\x01Score",
+		"Parquet_go_root\x01Info\x01Key_value\x01Key",
+		"Parquet_go_root\x01Info\x01Key_value\x01Value",
+		"Parquet_go_root\x01Sex",
+	}
+	assert.ElementsMatch(t, expectedValues, schemaHandler.ValueColumns)
+	structure := `Parquet_go_root
+  Info: Parquet_go_rootInfo
+    Key_value: Parquet_go_rootInfoKey_value
+      Key: Parquet_go_rootInfoKey_valueKey
+      Value: Parquet_go_rootInfoKey_valueValue
+  Sex: Parquet_go_rootSex
+  Name: Parquet_go_rootName
+  Age: Parquet_go_rootAge
+  Classes: Parquet_go_rootClasses
+    List: Parquet_go_rootClassesList
+      Element: Parquet_go_rootClassesListElement
+        Name: Parquet_go_rootClassesListElementName
+        Number: Parquet_go_rootClassesListElementNumber
+        Score: Parquet_go_rootClassesListElementScore
+`
+
+	var builder strings.Builder
+	builder = *schemaHandler.PathMap.output(&builder, "")
+	assert.ElementsMatch(t, strings.Split(structure, "\n"), strings.Split(builder.String(), "\n"))
+}
+
+func TestTagGeneration(t *testing.T) {
+	expected := make(map[string]*common.Tag)
+	expected["Sex"], _ = common.StringToTag("name=Sex, type=BOOLEAN")
+	expected["Info"], _ = common.StringToTag("type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, valuetype=BYTE_ARRAY, name=Info")
+	expected["Classes"], _ = common.StringToTag("type=LIST, convertedtype=LIST, name=Classes")
+	expected["Age"], _ = common.StringToTag("type=INT64, name=Age")
+	expected["Name"], _ = common.StringToTag("type=BYTE_ARRAY, name=Name")
+
+	actual := make(map[string]*common.Tag)
+	tp := reflect.TypeOf(StudentNoTag{})
+	for i := tp.NumField() - 1; i >= 0; i-- {
+		tagString, err := GenerateFieldTag(tp.Field(i))
+		if err != nil {
+			t.Errorf("failed to generate tag: %v", err)
+		}
+		actual[tp.Field(i).Name], _ = common.StringToTag(tagString)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("The tag is different")
+	}
+}


### PR DESCRIPTION
### Description

<!-- Please write a standard PR description here, and link to the plant that describes the broader context of this code change. Use [title][url] to create a link. -->

- Generate the go struct tag based on the mapping between go type and proto type to the parquet type
- Generate schema handler with the generated tags
- Special handling for the Enum(convert to string) and Timestamp(convert to int64 mills) proto specific use 
- Fix a few minor issues in the recursive handling slice 

[Log Analyzer Framework](https://docs.google.com/document/d/1dZGKIlg3sqaNgDupLJ1tiroQvEoLuZXxg81GFJ16vYI/edit)

### How this code was tested
<!-- Add unit/regression/scenario/manual tests used to test this feature -->
unit test.
`make test`


### Changelog
<!-- see link for more details/examples: https://docs.google.com/document/d/1GBHOgi1jsQgMqWfHg_2t1XUu5Bv9eUfGGQYQoKxKz1o
and this header for valid products/categories: https://docs.google.com/document/d/1GBHOgi1jsQgMqWfHg_2t1XUu5Bv9eUfGGQYQoKxKz1o/edit#heading=h.xjo5nf8ygjdh -->
+no-changelog

### Issues fixed (optional)
close #182667