### PR TITLE
[type] distinguish the string and byte array type

### DIFF
--- a/example/proto_write.go
+++ b/example/proto_write.go
@@ -46,6 +46,8 @@ type ProtoMessage struct {
 	Timestamp timestamppb.Timestamp
 	Status    JobStatus
 	IntVal    int32
+	Bytes     []byte
+	String    string
 }
 type TestInterface interface {
 	foo()
@@ -80,12 +82,12 @@ type TestInterfaceStruct struct {
 
 func main() {
 	protoMessages := []ProtoMessage{
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: 1000000}, Status: JobStatus_RUNNING, IntVal: 1},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: 1000000}, Status: JobStatus_ENQUEUED, IntVal: 2},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: 1000000}, Status: JobStatus_COMPLETED, IntVal: 3},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: 1000000}, Status: JobStatus_ERRORED, IntVal: 4},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: 1000000}, Status: JobStatus_CANCELLED, IntVal: 5},
-		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: 1000000}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 1, Nanos: 1000000}, Status: JobStatus_RUNNING, IntVal: 1, Bytes: []byte("test"), String: "test"},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 2, Nanos: 1000000}, Status: JobStatus_ENQUEUED, IntVal: 2, Bytes: []byte("test"), String: "test"},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 3, Nanos: 1000000}, Status: JobStatus_COMPLETED, IntVal: 3, Bytes: []byte("test"), String: "test"},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 4, Nanos: 1000000}, Status: JobStatus_ERRORED, IntVal: 4, Bytes: []byte("test"), String: "test"},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 5, Nanos: 1000000}, Status: JobStatus_CANCELLED, IntVal: 5, Bytes: []byte("test"), String: "test"},
+		ProtoMessage{Timestamp: timestamppb.Timestamp{Seconds: 6, Nanos: 1000000}, Status: JobStatus_UPSTREAM_NOT_PROCESSED, IntVal: 6, Bytes: []byte("test"), String: "test"},
 	}
 	impl2 := TestInterfaceImpl2{
 		Test:            "test",

--- a/schema/proto_test.go
+++ b/schema/proto_test.go
@@ -48,6 +48,8 @@ type ProtoMessage struct {
 	Timestamp timestamppb.Timestamp
 	Status    JobStatus
 	IntVal    int32
+	Bytes     []byte
+	String    string
 }
 
 func TestProtoSpecificSchema(t *testing.T) {
@@ -55,13 +57,19 @@ func TestProtoSpecificSchema(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to generate schema handler: %v", err)
 	}
-	assert.Equal(t, 3, len(schemaHandler.ValueColumns))
+	assert.Equal(t, 5, len(schemaHandler.ValueColumns))
 	assert.Equal(t, parquet.Type_INT64, *schemaHandler.SchemaElements[1].Type)
 	assert.Equal(t, parquet.ConvertedType_TIMESTAMP_MILLIS, *schemaHandler.SchemaElements[1].ConvertedType)
 	assert.Equal(t, parquet.Type_BYTE_ARRAY, *schemaHandler.SchemaElements[2].Type)
 	assert.Equal(t, parquet.ConvertedType_ENUM, *schemaHandler.SchemaElements[2].ConvertedType)
 	assert.Equal(t, parquet.Type_INT32, *schemaHandler.SchemaElements[3].Type)
 	assert.Nil(t, schemaHandler.SchemaElements[3].ConvertedType)
+	assert.Equal(t, parquet.Type_BYTE_ARRAY, *schemaHandler.SchemaElements[4].Type)
+	assert.Nil(t, schemaHandler.SchemaElements[4].ConvertedType)
+	assert.Nil(t, schemaHandler.SchemaElements[4].LogicalType)
+	assert.Equal(t, parquet.Type_BYTE_ARRAY, *schemaHandler.SchemaElements[5].Type)
+	assert.Nil(t, schemaHandler.SchemaElements[5].ConvertedType)
+	assert.NotNil(t, schemaHandler.SchemaElements[5].LogicalType.STRING)
 }
 
 func TestNewSchemaHandlerFromProtStruct(t *testing.T) {


### PR DESCRIPTION
### Description

<!-- Please write a standard PR description here -->

- In the parquet write, the bytes[] from proto should be stored as parquet Type_BYTE_ARRAY instead of array int. 
- string should stored with logical type STRING

### How this code was tested
<!-- Add unit/regression/manual tests used to test this feature -->
```
cd example
go run proto_write.go
parquet meta output/proto_message.parquet
parquet-tools show output/proto_message.parquet
```
